### PR TITLE
Fixed KeyError when passing 'id' in `attrs` and allows passing 'input_formats' to DateRangeField

### DIFF
--- a/django_bootstrap3_daterangepicker/fields.py
+++ b/django_bootstrap3_daterangepicker/fields.py
@@ -7,12 +7,8 @@ from django.utils.translation import string_concat
 from .widgets import DateRangeWidget
 
 
-class DateRangeField(forms.Field):
+class DateRangeField(forms.DateField):
     widget = DateRangeWidget
-
-    def __init__(self, base=forms.DateField(), **kwargs):
-        super(DateRangeField, self).__init__(**kwargs)
-        self.base = base
 
     def to_python(self, value):
         # Try to coerce the value to unicode.
@@ -24,12 +20,12 @@ class DateRangeField(forms.Field):
             parts = value.split(self.widget.separator, 2)
 
             try:
-                part1 = self.base.to_python(parts[0])
+                part1 = super().to_python(parts[0])
             except ValidationError as e:
                 raise ValidationError(string_concat('Error in period beginning: ', e.message), e.code)
 
             try:
-                part2 = self.base.to_python(parts[1])
+                part2 = super().to_python(parts[1])
             except ValidationError as e:
                 raise ValidationError(string_concat('Error in period end: ', e.message), e.code)
 

--- a/django_bootstrap3_daterangepicker/widgets.py
+++ b/django_bootstrap3_daterangepicker/widgets.py
@@ -117,9 +117,9 @@ class DateRangeWidget(forms.TextInput):
 
         options_js = json.dumps(options, default=convert_dates, indent="    ")
 
+        attrs = self.build_attrs(self.attrs, attrs)
         script = self.script_template.format(id=attrs['id'], options=options_js)
 
-        attrs = attrs or {}
         if 'class' not in attrs:
             attrs['class'] = 'form-control'
         return mark_safe(super(DateRangeWidget, self).render(name, value, attrs) + script)


### PR DESCRIPTION
Passing an ID as an attribute does not cause a KeyError anymore since using `build_attrs` merges the `attrs` in `__init__` and the `attrs` passed in `render`.

E.g. previously: 

    class MyForm(Form):
        field = DateField(widget=DateRangeWidget(attrs={'id': 'specific_id'}))
    
would raise a KeyError for `id` on `script = self.script_template.format(id=attrs['id'], options=options_js)`. 

Whereas now, the id is successfully include as an attribute as set when instantiating.

It was possible to change the widget format (e.g. to `'%d/%m/%Y'`), but submitting the form would return the wrong date objects, or raise a ValidationError due to the DateRangeField's `to_python()` method using `base` and therefore not accepting the `input_formats` set in self. 

Now to change the format for the widget and have fields that validate correctly, using similar arguments to core Django: 

    class SomeForm(Form)
        date_range_format = '%d/%m/%Y'

        date_range = DateRangeField(
            input_formats=[date_range_format],
            widget=DateRangeWidget(format=date_range_format, attrs={'id': date_range_id}))