### PR TITLE
Use force_str instead of deprecated force_text

### DIFF
--- a/django_bootstrap3_daterangepicker/fields.py
+++ b/django_bootstrap3_daterangepicker/fields.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils import six
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import string_concat, gettext_lazy as _
 
 from .widgets import DateRangeWidget
@@ -22,7 +22,7 @@ class DateRangeField(forms.Field):
 
     def to_python(self, value):
         # Try to coerce the value to unicode.
-        unicode_value = force_text(value, strings_only=True)
+        unicode_value = force_str(value, strings_only=True)
         if isinstance(unicode_value, six.text_type):
             value = unicode_value.strip()
         else:


### PR DESCRIPTION
Django will drop force_text in the next major version of Django. 